### PR TITLE
Patches to set proper permissions on password file

### DIFF
--- a/autoload/evervim.vim
+++ b/autoload/evervim.vim
@@ -12,10 +12,16 @@
 function! evervim#logincheck() " {{{
     try
     python << EOF
+import os
+import stat
 try:
     Evervimmer.getInstance().auth()
     print 'login successful.'
     f = open(os.path.join(vim.eval('g:evervim_workdir'),'evervim_account.txt'), 'w')
+	#
+	# ensure file is only accessible to current user.
+	#
+	os.chmod(f.name, stat.S_IWRITE | stat.S_IREAD)
     f.write(vim.eval("g:evervim_username"))
     f.write("\n")
     password = vim.eval("g:evervim_password")

--- a/plugin/evervim.vim
+++ b/plugin/evervim.vim
@@ -18,7 +18,7 @@ if !exists('g:evervim_workdir')
 endif
 
 if !isdirectory(g:evervim_workdir)
-    call mkdir(g:evervim_workdir, 'p')
+    call mkdir(g:evervim_workdir, 'p', 0700)
 endif
 
 if !exists('g:evervim_username')


### PR DESCRIPTION
commit 2fefd51e9e991d579b46bc5c8bd0a45b283fcb58 and commit 807ddfb90ea6b7a0c06abf50c3c99d07e7449808 in my fork make sure that evervim_account.txt and the folder containing it should only be accessible to the user running vim.

This works on Linux/unix, I haven't tested it on Windows but I believe it should work fine. Please merge :-).

(Yes, Windows has had multi-user file permissions for over 10 years now).
