### PR TITLE
Enable notebook specification when creating a new note.

### DIFF
--- a/autoload/evervim.vim
+++ b/autoload/evervim.vim
@@ -182,7 +182,8 @@ function! evervim#createNoteBuf() " {{{
 
     " clear buffer
     call append(0, "")
-    call append(1, "Tags:")
+    call append(1, "Notebook:")
+    call append(2, "Tags:")
     call cursor(1,0)
     setlocal nomodified
 

--- a/doc/evervim.txt
+++ b/doc/evervim.txt
@@ -71,8 +71,9 @@ choice one and <CR> too, the note will be displayd.
 
 Note is formatted
  1 line is Title
- 2 line is Tags (comma deliminated)
- 3 line after body
+ 2 line is Notebook (when empty the default notebook is used)
+ 3 line is Tags (comma deliminated)
+ 4 line after body
 
 If OpenBrowser plugin installed, you can open note on browser.
 (http://www.vim.org/scripts/script.php?script_id=3133)
@@ -180,6 +181,11 @@ g:evervim_splitoption				*g:evervim_splitoption*
 		open listwindow horizontal.
 
 		Default is 'v'. It means open vertical.
+
+g:evervim_defaultnotebook
+	       Contains the name of the default notebook. If no notebook is
+	       specified when a note is created, the note is saved to this
+	       notebook.
 
 
 Edit note on markdown or XML.

--- a/plugin/py/evervim_editor_test.py
+++ b/plugin/py/evervim_editor_test.py
@@ -67,20 +67,20 @@ class TestEvervimEditor(unittest.TestCase):
         EvervimPref.getInstance().xmlindent   = '    '  # default ts=4
         xmlStrings = editor.note2buffer(note)
         self.assertEqual(u'タイトルテスト'.encode('utf-8'), xmlStrings[0])
-        self.assertEqual(u'Tags:タグ１,*タグ２'.encode('utf-8'), xmlStrings[1])
-        self.assertEqual('this is content'.encode('utf-8'), xmlStrings[2])  # this is content
-        self.assertEqual('本文テスト'.encode('utf-8'), xmlStrings[3])       # 本文テスト
-        self.assertEqual('<h3>'.encode('utf-8'), xmlStrings[4])             # <h3>
-        self.assertEqual('    たぐ３'.encode('utf-8'), xmlStrings[5])       #     たぐ３
-        self.assertEqual('</h3>'.encode('utf-8'), xmlStrings[6])            # </h3>
+        self.assertEqual(u'Tags:タグ１,*タグ２'.encode('utf-8'), xmlStrings[2])
+        self.assertEqual('this is content'.encode('utf-8'), xmlStrings[3])  # this is content
+        self.assertEqual('本文テスト'.encode('utf-8'), xmlStrings[4])       # 本文テスト
+        self.assertEqual('<h3>'.encode('utf-8'), xmlStrings[5])             # <h3>
+        self.assertEqual('    たぐ３'.encode('utf-8'), xmlStrings[6])       #     たぐ３
+        self.assertEqual('</h3>'.encode('utf-8'), xmlStrings[7])            # </h3>
 
         EvervimPref.getInstance().usemarkdown = '1'  # dont use markdown
         mkdStrings = editor.note2buffer(note)
         self.assertEqual(u'# タイトルテスト'.encode('utf-8'), mkdStrings[0])
-        self.assertEqual(u'Tags:タグ１,*タグ２'.encode('utf-8'), xmlStrings[1])
-        self.assertEqual('this is content'.encode('utf-8'), mkdStrings[2])
-        self.assertEqual('本文テスト'.encode('utf-8'), mkdStrings[3])
-        self.assertEqual('### たぐ３'.encode('utf-8'), mkdStrings[4])
+        self.assertEqual(u'Tags:タグ１,*タグ２'.encode('utf-8'), xmlStrings[2])
+        self.assertEqual('this is content'.encode('utf-8'), mkdStrings[3])
+        self.assertEqual('本文テスト'.encode('utf-8'), mkdStrings[4])
+        self.assertEqual('### たぐ３'.encode('utf-8'), mkdStrings[5])
     # }}}
 
     def testBuffer2note(self):  # {{{

--- a/plugin/py/evervimmer.py
+++ b/plugin/py/evervimmer.py
@@ -52,6 +52,7 @@ class Evervimmer(object):
         self.pref.asyncupdate          = vim.eval("g:evervim_asyncupdate")
         self.pref.encoding             = vim.eval('&enc')
         self.pref.enscriptpath         = None
+        self.pref.defaultnotebook      = vim.eval("g:evervim_defaultnotebook")
     # }}}
 
     def setAPI(self):  # {{{


### PR DESCRIPTION
The format for creating a note is now as follows:
Title
Notebook: prefered notebook
Tags: tag1, tag2, ..
The text of the note.

When no note is given the default notebook is used. This default notebook can be
set with g:evervim_defaultnotebook .

---

Test scenarios:
1) Create new note with EvervimCreateNote
2) specify notebook (or leave empty for default)
3) save note
4) see that note is added to the specific notebook

1) Open existing note
2) Edit notebook to other
3) save
4) see that the note's notebook is changed
